### PR TITLE
Allow for versions of node greater than the 0.4.12 (i.e., 0.6.x is now gaining in use)

### DIFF
--- a/bin/nserv
+++ b/bin/nserv
@@ -3,7 +3,7 @@
 // modules
 var commander = require('commander'),
     fs = require('fs'),
-    sys = require("sys"),
+    sys = require("util"),
     exec  = require('child_process').exec,
     http = require('http'),
     colors = require('colors'),

--- a/package.json
+++ b/package.json
@@ -17,6 +17,6 @@
     "nserv": "./bin/nserv"
   },
   "engines": {
-    "node": "0.4.12"
+    "node": ">= 0.4.12"
   }
 }


### PR DESCRIPTION
Just noticed this after building node on a fresh install and trying to pull in `nserv` via NPM; it threw an error due to node version incompatibility. 

Awesome work.
